### PR TITLE
add base64_encode for lock_file path

### DIFF
--- a/rss.php
+++ b/rss.php
@@ -185,7 +185,7 @@ $stash = '/tmp/fengqi-transmission-rss';
 $trans = new Transmission($server, $port, $rpcPath, $user, $password);
 $torrents = $trans->getRssItems($rss);
 foreach ($torrents as $torrent) {
-    $lock_file = $stash.'/'.$torrent['guid'];
+    $lock_file = $stash.'/'.base64_encode($torrent['guid']);
     if (file_exists($lock_file)) {
         printf("%s: skip add: %s\n", date('Y-m-d H:i:s'), $torrent['title']);
         continue;


### PR DESCRIPTION
Added base64_encode for torrent['guid'], because some rss feeds contained url address in "guid" such as "litr.cc", and variable lock_file contained wrong file path.